### PR TITLE
Fix invalid resource properties error when create consumer with both username and custom_id defined

### DIFF
--- a/src/cfn_kong_consumer_provider.py
+++ b/src/cfn_kong_consumer_provider.py
@@ -23,7 +23,7 @@ request_schema = {
         },
         "Consumer": {
             "type": "object",
-            "oneOf": [{
+            "anyOf": [{
                 "properties": {
                     "custom_id": {
                         "type": "string"


### PR DESCRIPTION
Issue: https://github.com/binxio/cfn-kong-provider/issues/1