### PR TITLE
Removing outdated ratelimit parameter did not work when object was removed from parameter object in cfn yaml

### DIFF
--- a/cloudformation/cfn-resource-provider.yaml
+++ b/cloudformation/cfn-resource-provider.yaml
@@ -85,4 +85,4 @@ Resources:
         - SecurityGroupIds:
             - !Ref 'DefaultSecurityGroup'
           SubnetIds: !Ref 'PrivateSubnets'
-      Runtime: python3.6
+      Runtime: python3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3
 cfn_resource_provider>=1.0.3
 jwt_generator
-cryptography
+cryptography==3.4.8
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3
-cfn_resource_provider>=1.0.3
+cfn_resource_provider>=1.0.6
 jwt_generator
 cryptography==3.4.8
 requests

--- a/src/cfn_kong_plugin_provider.py
+++ b/src/cfn_kong_plugin_provider.py
@@ -71,6 +71,16 @@ class KongPluginProvider(KongProvider):
         super(KongPluginProvider, self).__init__('plugins', 'Plugin')
         self.request_schema = request_schema
 
+    # override
+    def transform_before_patch(self, property_name):
+        new_config = self.get(property_name)
+        if new_config['name'] == 'rate-limiting':
+            old_config = self.get_old(property_name)
+            removed_settings = {key: None for key in old_config['config'].keys() - new_config['config'].keys()}
+            new_config['config'].update(removed_settings)
+        return new_config
+
+
 provider = KongPluginProvider()
 
 

--- a/src/cfn_kong_provider.py
+++ b/src/cfn_kong_provider.py
@@ -34,7 +34,7 @@ class KongProvider(ResourceProvider):
                 jwt.set_private_key(private_key.encode('ascii'))
                 jwt.generate()
 
-                self.headers['Authorization'] = 'Bearer %s' % jwt.token#.decode('ascii')
+                self.headers['Authorization'] = 'Bearer %s' % jwt.token
             except ClientError as e:
                 self.fail('could not get private key, %s' % e.response['Error'])
                 return False

--- a/src/cfn_kong_provider.py
+++ b/src/cfn_kong_provider.py
@@ -34,7 +34,7 @@ class KongProvider(ResourceProvider):
                 jwt.set_private_key(private_key.encode('ascii'))
                 jwt.generate()
 
-                self.headers['Authorization'] = 'Bearer %s' % jwt.token.decode('ascii')
+                self.headers['Authorization'] = 'Bearer %s' % jwt.token#.decode('ascii')
             except ClientError as e:
                 self.fail('could not get private key, %s' % e.response['Error'])
                 return False
@@ -66,7 +66,8 @@ class KongProvider(ResourceProvider):
             url = '%s/%s' % (self.resource_url, self.physical_resource_id)
 
             try:
-                response = requests.patch(url, headers=self.headers, json=self.get(self.property_name))
+                json = self.transform_before_patch(self.property_name)
+                response = requests.patch(url, headers=self.headers, json=json)
                 if response.status_code in (200, 201):
                     r = response.json()
                     self.physical_resource_id = r['id']
@@ -75,6 +76,9 @@ class KongProvider(ResourceProvider):
                     self.fail('Could not update the %s, %s' % (self.property_name, response.text))
             except IOError as e:
                 self.fail('Could not update the %s, %s' % (self.property_name, str(e)))
+
+    def transform_before_patch(self, property_name):
+        return self.get(property_name)
 
     def delete(self):
         if self.add_jwt():


### PR DESCRIPTION
We discovered that with the ratelimit plugins when removing objects from the parameter object, say when switching from ratelimiting from minutes to seconds, the plugin did not null the old minutes object, and there we had 'hidden' ratelimit stats on our routes or consumers.

This fix changes things so that when an object is no longer in the new settings, the old setting gets nulled on the kong object in question. 

for example:

`  PublicUploadRateLimiting:
      Type: Custom::KongPlugin
      Properties:
        Plugin:
          name: rate-limiting
          route:
            id: !GetAtt 'PublicUploadRoute.id'
          protocols:
            - http
            - https
          config:
            fault_tolerant: true
            second: 20
        ServiceToken: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:binxio-cfn-kong-provider-${AppVPC}'
        AdminURL: !Sub 'https://admin.${ExternalDomainName}/kong-api/v1'
        JWT:
          Issuer: admin
          PrivateKeyParameterName: !Sub '/${DomainName}/kong/consumers/admin/private-key'
`

to 

`  PublicUploadRateLimiting:
      Type: Custom::KongPlugin
      Properties:
        Plugin:
          name: rate-limiting
          route:
            id: !GetAtt 'PublicUploadRoute.id'
          protocols:
            - http
            - https
          config:
            fault_tolerant: true
            minute: 20
        ServiceToken: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:binxio-cfn-kong-provider-${AppVPC}'
        AdminURL: !Sub 'https://admin.${ExternalDomainName}/kong-api/v1'
        JWT:
          Issuer: admin
          PrivateKeyParameterName: !Sub '/${DomainName}/kong/consumers/admin/private-key'
`

This prevents hidden ratelimit settings or issues with deployment because kong does not accept the ratelimit due to the new settings not fitting in the old one.

test has also been added to prevent issues in future testing / changes.